### PR TITLE
Fix link to device-insight.com

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-[Device Insight](https://device-insight.com) has been founded in 2003 and has realized
+[Device Insight](https://www.device-insight.com) has been founded in 2003 and has realized
 more than 150 IoT projects across all industries. Our projects and solutions are all
 based on our CENTERSIGHT cloud platform.
 


### PR DESCRIPTION
https://device-insight.com gives a TLS certificate error. The link must include the "www."